### PR TITLE
For cron_parser itself, default chrono features aren't needed.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ edition = "2018"
 travis-ci = { repository = "nbari/cron-parser", branch = "master" }
 
 [dependencies]
-chrono = "0.4.24"
+chrono = {version="0.4.24", default-features=false}
 
 [dev-dependencies]
+chrono = {version="0.4.24", default-features=false, features=["clock"]}
 chrono-tz = "0.8.1"
 criterion = "0.4.0"
 


### PR DESCRIPTION
This gets rid of a cargo audit error for the time crate.
Note that tests at least need the clock feature, so that's the reason for the two entries.
